### PR TITLE
change for ... in to for ... of

### DIFF
--- a/app.js
+++ b/app.js
@@ -180,7 +180,7 @@ const getVerseEndSymbol = (verseNumber, arabicNumeral = true) => {
     9: "۹",
   };
 
-  for (const e in digits) {
+  for (const e of digits) {
     arabicNumeric += arabicNumbers[e];
   }
 


### PR DESCRIPTION
Change the for loop to iterate through the **values** of `digits` and not the **indices**. This a bug fix for wrong verse numbers.

Previously, `getVerseEndSymbol` always returned ٠ for one-digit numbers, ٠۱ for two-digit numbers, ٠۱۲ for three-digit numbers, and so on.